### PR TITLE
Allow different VLAN tagging in accel-ppp

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,43 @@ The Makefile defines targets for building and running the containers:
 
 ```
 make build
-make run
+make start
+```
+
+or equivalently:
+
+```
+make
+```
+
+You can also separately build the images and start the containers:
+
+```
+build-accel-ppp-drivers
+start-accel-ppp-drivers
+```
+
+and
+
+```
+build-accel-pppd
+start-accel-pppd
 ```
 
 Please note that we currently only support ubuntu host machines. The
 `KERNEL_VERSION` of the host system can be specified to build the kernel
 modules for certain kernel versions. By default the kernel version is read by
 `uname -r`.
+
+## Setting VLAN tags
+The accel-ppp container is able to create VLAN interfaces before it starts
+accel-ppp. The VLAN tags can be configured in the `environment` section of
+`accel-pppd` in the `docker-compose.yml`. A single outer tag can be specified
+as well as a list of inner tags. If no inner tags are specified the entrypoint
+script of accel-ppp will create interfaces for all VLANs 1-4094. If outer tag
+is 0 the script creates VLAN interfaces, that are not stacked. The proto can be
+either 802.1ad (S-tag) or 802.1Q (C-tag).
+
 
 ## Test
 We use [test-kitchen](https://kitchen.ci/) with the vagrant driver

--- a/accel-pppd/docker-entrypoint.sh
+++ b/accel-pppd/docker-entrypoint.sh
@@ -1,28 +1,42 @@
 #!/bin/bash
 set -e
 
-OUTER_TAG=${OUTER_TAG_TAG:-700}
-INNER_TAGS="$(echo {0..4094})"
+OUTER_PROTO=${OUTER_PROTO:-802.1ad}
+OUTER_TAG=${OUTER_TAG:-0}
+INNER_PROTO=${INNER_PROTO:-802.1Q}
+INNER_TAGS=${INNER_TAGS:-$(echo {0..4094})}
 IFACE=${IFACE:-eth0}
 CORES="$(grep -c ^processor /proc/cpuinfo)"
 
 create_vlan_interface () {
     iface=$1
     tag=$2
-    proto=${3:-802.1Q}
+    proto=$3
     vlan_iface=$iface.$tag
     ip link add link $iface $vlan_iface type vlan proto $proto id $tag
     ip link set $vlan_iface up
     echo "$vlan_iface"
 }
 
-# Create interface for outer C-tag
-OUTER_IFACE=$(create_vlan_interface $IFACE $OUTER_TAG)
+if [[ $OUTER_TAG -eq 0 ]]; then # No outer tag
+    # Only single VLAN tag, no stacking
+    OUTER_IFACE=$IFACE
+elif [[ $OUTER_TAG -gt 0 && $OUTER_TAG -lt 4095 ]]; then
+    # Create outer VLAN interface
+    OUTER_IFACE=$(create_vlan_interface $IFACE $OUTER_TAG $OUTER_PROTO)
+else
+    >&2 echo "Value $OUTER_TAG for OUTER_TAG not valid."
+    exit 1
+fi
 
-# Create interfaces for inner C-tags
-export -f create_vlan_interface
-export OUTER_IFACE
-printf %s\\n $INNER_TAGS | xargs -n 1 -P $CORES -I {} bash -c 'create_vlan_interface "$OUTER_IFACE" "{}" &> /dev/null'
+# Create inner VLAN interfaces
+if [[ ! -z $INNER_TAGS ]]; then
+    export -f create_vlan_interface
+    export OUTER_IFACE
+    export INNER_PROTO
+
+    printf "$INNER_TAGS" | xargs -d " " -n 1 -P $CORES -I {} bash -c 'create_vlan_interface "$OUTER_IFACE" "{}" "$INNER_PROTO" &> /dev/null'
+fi
 
 # Run command from CMD
 exec "$@"

--- a/accel-pppd/docker-entrypoint.sh
+++ b/accel-pppd/docker-entrypoint.sh
@@ -1,36 +1,28 @@
 #!/bin/bash
 set -e
 
-S_TAG=${S_TAG:-0}
-C_TAGS="$(echo {0..4094})"
+OUTER_TAG=${S_TAG:-0}
+INNER_TAGS="$(echo {0..4094})"
 IFACE=${IFACE:-eth0}
 CORES="$(grep -c ^processor /proc/cpuinfo)"
 
-create_s_tag () {
+create_vlan_interface () {
     iface=$1
-    s_tag=$2
-    s_iface=$iface.$s_tag
-    ip link add link $iface $s_iface type vlan proto 802.1ad id $s_tag
-    ip link set $s_iface up
-    echo "$s_iface"
+    tag=$2
+    proto=${3:-802.1Q}
+    vlan_iface=$iface.$tag
+    ip link add link $iface $vlan_iface type vlan proto proto id $tag
+    ip link set $vlan_iface up
+    echo "$vlan_iface"
 }
 
-create_c_tag () {
-    iface=$1
-    c_tag=$2
-    c_iface=$iface.$c_tag
-    ip link add link $iface $c_iface type vlan proto 802.1Q id $c_tag
-    ip l set $c_iface up
-    echo "$c_iface"
-}
+# Create interface for outer C-tag
+OUTER_IFACE=$(create_vlan_interface $IFACE $OUTER_TAG)
 
-# Create interface for S-tag
-S_IFACE=$(create_s_tag $IFACE $S_TAG)
-
-# Create interfaces for C-tags
-export -f create_c_tag
-export S_IFACE
-printf %s\\n $C_TAGS | xargs -n 1 -P $CORES -I {} bash -c 'create_c_tag "$S_IFACE" "{}" &> /dev/null'
+# Create interfaces for inner C-tags
+export -f create_vlan_interface
+export OUTER_IFACE
+printf %s\\n $INNER_TAGS | xargs -n 1 -P $CORES -I {} bash -c 'create_vlan_interface "$OUTER_IFACE" "{}" &> /dev/null'
 
 # Run command from CMD
 exec "$@"

--- a/accel-pppd/docker-entrypoint.sh
+++ b/accel-pppd/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-OUTER_TAG=${S_TAG:-0}
+OUTER_TAG=${OUTER_TAG_TAG:-700}
 INNER_TAGS="$(echo {0..4094})"
 IFACE=${IFACE:-eth0}
 CORES="$(grep -c ^processor /proc/cpuinfo)"
@@ -11,7 +11,7 @@ create_vlan_interface () {
     tag=$2
     proto=${3:-802.1Q}
     vlan_iface=$iface.$tag
-    ip link add link $iface $vlan_iface type vlan proto proto id $tag
+    ip link add link $iface $vlan_iface type vlan proto $proto id $tag
     ip link set $vlan_iface up
     echo "$vlan_iface"
 }

--- a/accel-pppd/etc/accel-ppp.conf
+++ b/accel-pppd/etc/accel-ppp.conf
@@ -8,7 +8,7 @@ pptp
 l2tp
 #sstp
 pppoe
-ipoe
+#ipoe
 
 #auth_mschap_v2
 #auth_mschap_v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3'
+services:
+  accel-ppp-drivers:
+    build:
+        context: ./accel-ppp-drivers/ubuntu/
+        args:
+            - KERNEL_VERSION=$KERNEL_VERSION
+            - UBUNTU_VERSION=$UBUNTU_VERSION
+    volumes:
+      - /sbin/modprobe:/sbin/modprobe
+      - /sbin/depmod:/sbin/depmod
+      - /lib/modules/$KERNEL_VERSION:/lib/modules/$KERNEL_VERSION
+      - /etc/modules-load.d/:/etc/modules-load.d
+    cap_add:
+      - SYS_MODULE
+  accel-pppd:
+    depends_on:
+        - accel-ppp-drivers
+    build: ./accel-pppd/
+    devices:
+      - /dev/ppp:/dev/ppp
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - 2000-2001:2000-2001
+    environment:
+      - IFACE=eth0
+      - OUTER_PROTO=802.1Q
+      - OUTER_TAG=700
+      - INNER_PROTO=802.1Q
+      - INNER_TAGS=45 46


### PR DESCRIPTION
The current hardeware filtering doesn't support QinQ tags (S-tag +
C-tag). Move to double C-tagged interfaces.